### PR TITLE
fix: edit title by default with autosave enabled

### DIFF
--- a/src/components/ConversationSettings.tsx
+++ b/src/components/ConversationSettings.tsx
@@ -88,34 +88,36 @@ const ConversationSettings = ({
   }, [temperature])
 
   return (
-    <div className="ai-research-assistant__chat__conversation-settings">
-      <div className="ai-research-assistant__chat__conversation-settings__row">
-        <InputArea
-          type="text"
-          label="User Handle"
-          value={userHandle}
-          onChange={setUserHandle}
-        />
-        <InputArea
-          type="text"
-          label="Bot Handle"
-          value={botHandle}
-          onChange={setBotHandle}
-        />
-      </div>
-      <div className="ai-research-assistant__chat__conversation-settings__row">
-        <InputArea
-          type="text"
-          label="Maximum Tokens"
-          value={`${maxTokens}`}
-          onChange={changeMaxTokens}
-        />
-        <InputArea
-          type="text"
-          label="Temperature"
-          value={`${temperature}`}
-          onChange={changeTemperature}
-        />
+    <div className="ai-research-assistant__chat__conversation-settings__container">
+      <div className="ai-research-assistant__chat__conversation-settings">
+        <div className="ai-research-assistant__chat__conversation-settings__row">
+          <InputArea
+            type="text"
+            label="User Handle"
+            value={userHandle}
+            onChange={setUserHandle}
+          />
+          <InputArea
+            type="text"
+            label="Bot Handle"
+            value={botHandle}
+            onChange={setBotHandle}
+          />
+        </div>
+        <div className="ai-research-assistant__chat__conversation-settings__row">
+          <InputArea
+            type="text"
+            label="Maximum Tokens"
+            value={`${maxTokens}`}
+            onChange={changeMaxTokens}
+          />
+          <InputArea
+            type="text"
+            label="Temperature"
+            value={`${temperature}`}
+            onChange={changeTemperature}
+          />
+        </div>
       </div>
     </div>
   )

--- a/src/styles.css
+++ b/src/styles.css
@@ -68,10 +68,10 @@
   width: 100%;
   height: auto;
   font-size: var(--font-small);
-  padding: 0 25px 0 5px;
+  padding: 5px 25px 5px 5px;
   border: var(--input-border-width) solid var(--background-modifier-border);
   border-radius: 0;
-  margin: 0;
+  margin: 0 0 0 5px;
 }
 
 .ai-research-assistant__conversation__header__edit {
@@ -348,13 +348,22 @@
   color: var(--text-muted);
 }
 
-.ai-research-assistant__input-area__toolbar {
+.ai-research-assistant__input-area__toolbar,
+.ai-research-assistant__chat__conversation-settings__container {
   display: flex;
   position: absolute;
   width: 100%;
   flex-direction: row;
   font-size: var(--font-smallest);
   color: var(--text-faint);
+}
+
+.ai-research-assistant__chat__conversation-settings__container {
+  height: 85%;
+  background: var(--background-modifier-form-field);
+  border: var(--input-border-width) solid var(--background-modifier-border);
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 .ai-research-assistant__input-area__toolbar--top {

--- a/src/templates/summaryTemplate.ts
+++ b/src/templates/summaryTemplate.ts
@@ -47,17 +47,13 @@ ${
   typeof conversation?.preamble !== 'undefined' &&
   conversation.preamble !== '' &&
   conversation.preamble !== null
-    ? `
-
-## Preamble
+    ? `## Preamble
 
 The initial preamble used for this conversation was:
 
 \`\`\`
 ${conversation.preamble}
-\`\`\`
-
-`
+\`\`\``
     : ''
 }
 


### PR DESCRIPTION
This also adds some basic style to the Conversation Settings tab to make it more visually consistent with the rest of the tabs.

Closes #1
