### PR TITLE
feat: leverage safeStorage for OpenAI API Key; clean up legacy features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ![Forgetting a previous message](./docs/assets/forget-memory.png)
 
-> Build better Prompts and AI integrations with this advanced research tool for Prompt Engineering.
+> Build better Prompts and AI integrations with this advanced research tool for Prompt Engineering with the ChatGPT API.
 
-**Note**: This plugin is still in active development and is not considered Stable yet. **This is Beta
+**Note**: This plugin is still in development and is not considered fully stable yet. **This is Beta
 software** and may contain bugs and unexpected behaviors. Please report
 [Issues](https:/github.com/InterwebAlchemy/obsidian-ai-research-assistant/issues) you find and feel
-encouraged to [contribute](https://github.com/InterwebAlchemy/obsidian-ai-research-assistant/blob/main/docs/CONTRIBUTING.md) to the project. It has only been tested on Obsidian Desktop so far, but should have Obsidian Mobile support in the near future.
+encouraged to [contribute](https://github.com/InterwebAlchemy/obsidian-ai-research-assistant/blob/main/docs/CONTRIBUTING.md) to the project.
 
 **Table of Contents**:
 
@@ -49,16 +49,14 @@ This plugin is not yet available in the Obsidian Community Plugins directory, so
 
 - [OpenAI GPT-3](https://platform.openai.com/docs/models/gpt-3)
   - `gpt-3.5-turbo`
-  - `text-davinci-003`
 
 ## Upcoming Model Support
 
-- [OpenAI GPT-3](https://platform.openai.com/docs/models/gpt-3)
-  - `text-curie-001`
-- [OpenAPI Codex](https://platform.openai.com/docs/models/codex)
-  - `code-davinci-002`
-  - `code-cushman-001`
-- [Cohere AI Models](https://docs.cohere.ai/reference/generate)
+- [OpenAI GPT-4](https://platform.openai.com/docs/models/gpt-4)
+  - `gpt-4`
+- [OpenAI Legacy Completions API](https://platform.openai.com/docs/deprecations/instructgpt-models)
+  - `gpt-3.5-turbo-instruct`
+  - **Note**: This plugin was originally built when only the completions API was available and was built to support the `text-davinci-003` model, but with recent changes in the OpenAI API, it is now recommended to use the `gpt-3.5-turbo` model instead and `text-daivinci-003` is being deprecated, so that functionality has been temporarily disabled in this plugin.
 
 ## Summary
 
@@ -132,7 +130,7 @@ between what you might be editing when you click on an `Edit Prompt` button.
 - **Prompt**: Prompts are the questions that the model is asked to answer. They are usually a single
   sentence or a short paragraph.
   - **Notable Examples**:
-    - [Emergent Mind](https://www.emergentmind.com/)
+    - [ShareGPT](https://sharegpt.com/)
     - [OpenAI Examples](https://platform.openai.com/examples/)
 - **Context**: Context is the memory that the model uses to generate its response. It usually
   consists of the Preamble and some previous messages (or summaries them), and older messages are

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -46,15 +46,15 @@ export default class ObsidianAIResearchAssistant extends Plugin {
 
   async initializeChatService(): Promise<void> {
     if (
-      typeof this.settings.openApiKey !== 'undefined' &&
-      this.settings.openApiKey !== '' &&
-      this.settings.openApiKey !== null
+      typeof this.settings.openAiApiKey !== 'undefined' &&
+      this.settings.openAiApiKey !== '' &&
+      this.settings.openAiApiKey !== null
     ) {
       const model = OpenAIModels[this.settings.defaultModel]
 
       if (typeof model !== 'undefined') {
         this.chat = new Chat({
-          apiKey: this.settings.openApiKey,
+          apiKey: this.settings.openAiApiKey,
           model,
           logger: this.logger
         })
@@ -68,9 +68,9 @@ export default class ObsidianAIResearchAssistant extends Plugin {
       PLUGIN_NAME,
       async (): Promise<void> => {
         if (
-          typeof this.settings.openApiKey !== 'undefined' &&
-          this.settings.openApiKey !== '' &&
-          this.settings.openApiKey !== null
+          typeof this.settings.openAiApiKey !== 'undefined' &&
+          this.settings.openAiApiKey !== '' &&
+          this.settings.openAiApiKey !== null
         ) {
           await this.activateView()
         } else {
@@ -125,11 +125,7 @@ export default class ObsidianAIResearchAssistant extends Plugin {
 
     const existingFile = this.app.vault.getAbstractFileByPath(file)
 
-    if (existingFile !== null) {
-      return true
-    }
-
-    return false
+    return existingFile instanceof TFile
   }
 
   async saveConversation(conversation: Conversation): Promise<void> {
@@ -160,8 +156,8 @@ export default class ObsidianAIResearchAssistant extends Plugin {
 
       const fileContent = summaryTemplate(conversation)
 
-      if (existingFile !== null) {
-        await this.app.vault.modify(existingFile as TFile, fileContent)
+      if (existingFile instanceof TFile) {
+        await this.app.vault.modify(existingFile, fileContent)
       } else {
         await this.app.vault.create(file, fileContent)
       }

--- a/src/services/openai/models/index.ts
+++ b/src/services/openai/models/index.ts
@@ -1,11 +1,8 @@
-import TextDavinci003 from './text-davinci-003'
 import GPT35Turbo from './gpt-3.5-turbo'
 
 const models = {
-  'gpt-3.5-turbo': GPT35Turbo,
-  // TODO: enable the code davinci model and connect it with the openai code adapter
-  // 'code-davinci-002': CodeDavinci002,
-  'text-davinci-003': TextDavinci003
+  'gpt-3.5-turbo': GPT35Turbo
+  // TODO: connect to OpenAI API and get available models
 }
 
 export default models

--- a/src/services/openai/types.ts
+++ b/src/services/openai/types.ts
@@ -5,7 +5,7 @@ import type { ChatAdapter } from '../../types'
 import type { TokenCounterType } from '../../utils/tokenCounter'
 
 // TODO: add other models
-export type OpenAIModel = 'gpt-3.5-turbo' | 'text-davinci-003'
+export type OpenAIModel = 'gpt-3.5-turbo'
 // | 'code-davinci-002'
 
 // TODO: find out what other valid object values are

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface ChatAdapter {
 export interface PluginSettings {
   debugMode: boolean
 
-  openApiKey: string
+  openAiApiKey: string
   apiKeySaved: boolean
 
   defaultModel: OpenAIModel

--- a/src/utils/obfuscateApiKey.ts
+++ b/src/utils/obfuscateApiKey.ts
@@ -1,3 +1,4 @@
-const obfuscateApiKey = (apiKey: string): string => apiKey.replace(/^(.{3})(.*)(.{4})$/, '$1****$3')
+const obfuscateApiKey = (apiKey = ''): string =>
+  apiKey.length > 0 ? apiKey.replace(/^(.{3})(.*)(.{4})$/, '$1****$3') : ''
 
 export default obfuscateApiKey


### PR DESCRIPTION
### What does this PR do?

Moves to Electron's `safeStorage` API for storing OpenAI API Key.

Removes some legacy functionality and settings that have been deprecated since this plugin was originally created.

### Motivation

API keys in plaintext are bad.

### Additional Notes

Closes #7 

I think this means that each desktop device (because this prevents the plugin from running on mobile now) needs to add the API key individually, which isn't ideal, but is a better tradeoff than exposing the API key in plaintext.
