### PR TITLE
feat: add gpt-3.5-turbo-instruct, gpt-4-32k, and gpt-3.5-turbo-16k

### DIFF
--- a/src/components/ConversationSettings.tsx
+++ b/src/components/ConversationSettings.tsx
@@ -5,10 +5,7 @@ import InputArea from './InputArea'
 import { useApp } from '../hooks/useApp'
 
 import type { Conversation } from '../services/conversation'
-import {
-  OPEN_AI_DEFAULT_TEMPERATURE,
-  OPEN_AI_DEFAULT_MODEL_NAME
-} from '../services/openai/constants'
+import { OPEN_AI_DEFAULT_TEMPERATURE } from '../services/openai/constants'
 import models from '../services/openai/models'
 import type { OpenAIModel } from 'src/services/openai/types'
 
@@ -25,10 +22,6 @@ const ConversationSettings = ({
 
   const [userHandle, setUserHandle] = useState('')
   const [botHandle, setBotHandle] = useState('')
-  const [maxTokens, setMaxTokens] = useState(0)
-  const [model, setModel] = useState<OpenAIModel>(
-    conversation?.model.model ?? OPEN_AI_DEFAULT_MODEL_NAME
-  )
   const [temperature, setTemperature] = useState(
     `${OPEN_AI_DEFAULT_TEMPERATURE}`
   )
@@ -37,21 +30,18 @@ const ConversationSettings = ({
     setTemperature(temperatureString)
   }
 
-  const changeMaxTokens = (maxTokensString: string): void => {
-    setMaxTokens(Number(maxTokensString))
-  }
-
   const changeModel = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     const modelName = e.target.value
 
-    setModel(modelName as OpenAIModel)
+    if (typeof conversation !== 'undefined' && conversation !== null) {
+      conversation.updateModel(models[modelName as OpenAIModel])
+    }
   }
 
   useEffect(() => {
     if (typeof settings !== 'undefined') {
       setUserHandle(settings.userHandle)
       setBotHandle(settings.botHandle)
-      setMaxTokens(settings.defaultMaxTokens ?? 0)
     }
   }, [settings])
 
@@ -87,16 +77,6 @@ const ConversationSettings = ({
     if (
       typeof conversation !== 'undefined' &&
       conversation !== null &&
-      maxTokens !== conversation?.settings.defaultMaxTokens
-    ) {
-      conversation.settings.defaultMaxTokens = maxTokens
-    }
-  }, [maxTokens])
-
-  useEffect(() => {
-    if (
-      typeof conversation !== 'undefined' &&
-      conversation !== null &&
       Number(temperature) !== conversation?.settings.temperature
     ) {
       const temp = Number(temperature)
@@ -110,18 +90,8 @@ const ConversationSettings = ({
     }
   }, [temperature])
 
-  useEffect(() => {
-    if (
-      typeof conversation !== 'undefined' &&
-      conversation !== null &&
-      model !== conversation?.model.model
-    ) {
-      conversation.updateModel(models[model])
-    }
-  }, [model])
-
   const renderModels = (
-    selectedModel = OPEN_AI_DEFAULT_MODEL_NAME
+    selectedModel = settings.defaultModel
   ): React.ReactElement[] => {
     return Object.entries(models).map(([key, modelDefinition]) => (
       <option key={key} value={modelDefinition.model}>
@@ -131,8 +101,10 @@ const ConversationSettings = ({
   }
 
   const renderModelDropdown = (
-    defaultModel = OPEN_AI_DEFAULT_MODEL_NAME
+    defaultModel = settings.defaultModel
   ): React.ReactElement => {
+    console.log(defaultModel, settings.defaultModel)
+
     return (
       <select
         name="model"
@@ -149,7 +121,22 @@ const ConversationSettings = ({
     <div className="ai-research-assistant__chat__conversation-settings__container">
       <div className="ai-research-assistant__chat__conversation-settings">
         <div className="ai-research-assistant__chat__conversation-settings__row">
-          {renderModelDropdown(model)}
+          <div className="ai-research-assistant__input-area">
+            <label
+              className="ai-research-assistant__input-area__input__label"
+              htmlFor="model">
+              Model
+            </label>
+            {renderModelDropdown(
+              conversation?.model.model ?? settings.defaultModel
+            )}
+          </div>
+          <InputArea
+            type="text"
+            label="Temperature"
+            value={`${temperature}`}
+            onChange={changeTemperature}
+          />
         </div>
         <div className="ai-research-assistant__chat__conversation-settings__row">
           <InputArea
@@ -163,20 +150,6 @@ const ConversationSettings = ({
             label="Bot Handle"
             value={botHandle}
             onChange={setBotHandle}
-          />
-        </div>
-        <div className="ai-research-assistant__chat__conversation-settings__row">
-          <InputArea
-            type="text"
-            label="Maximum Tokens"
-            value={`${maxTokens}`}
-            onChange={changeMaxTokens}
-          />
-          <InputArea
-            type="text"
-            label="Temperature"
-            value={`${temperature}`}
-            onChange={changeTemperature}
           />
         </div>
       </div>

--- a/src/components/SidebarView.tsx
+++ b/src/components/SidebarView.tsx
@@ -10,7 +10,10 @@ import { useApp } from '../hooks/useApp'
 
 import type { Conversation } from '../services/conversation'
 
-import { OPEN_AI_CHAT_COMPLETION_OBJECT_TYPE } from '../services/openai/constants'
+import {
+  OPEN_AI_CHAT_COMPLETION_OBJECT_TYPE,
+  OPEN_AI_COMPLETION_OBJECT_TYPE
+} from '../services/openai/constants'
 
 export interface ChatFormProps {
   onChatUpdate?: () => Promise<void>
@@ -41,7 +44,9 @@ const SidebarView = ({ onChatUpdate }: ChatFormProps): React.ReactElement => {
     setPrompt('')
 
     chat
-      ?.send(prompt, { signal: cancelPromptController.signal })
+      ?.send(prompt, {
+        signal: cancelPromptController.signal
+      })
       .then(async (responseStream: Stream<OpenAI.Chat.ChatCompletionChunk>) => {
         let accumulatedMessage = ''
 
@@ -72,7 +77,10 @@ const SidebarView = ({ onChatUpdate }: ChatFormProps): React.ReactElement => {
                 id,
                 model,
                 created,
-                object: OPEN_AI_CHAT_COMPLETION_OBJECT_TYPE,
+                object:
+                  conversation?.model?.adapter?.engine === 'chat'
+                    ? OPEN_AI_CHAT_COMPLETION_OBJECT_TYPE
+                    : OPEN_AI_COMPLETION_OBJECT_TYPE,
                 choices: [
                   {
                     message: {
@@ -111,7 +119,11 @@ const SidebarView = ({ onChatUpdate }: ChatFormProps): React.ReactElement => {
   }
 
   const cancelPromptSubmit = (event: React.FormEvent): void => {
-    logger.debug(`Cancelling streaming response from ${conversation?.model?.adapter?.name as string}...`)
+    logger.debug(
+      `Cancelling streaming response from ${
+        conversation?.model?.adapter?.name as string
+      }...`
+    )
 
     cancelPromptController.abort()
   }

--- a/src/preambles/assistant.ts
+++ b/src/preambles/assistant.ts
@@ -6,7 +6,7 @@ const AssistantPreamble = (date = new Date()): string =>
 You are Assisant, a large language model trained by OpenAI. You answer as concisely as possible for each response (e.g. don't be verbose). It is very important that you answer as concisely as possible, so please remember this. If you are generating a list, it does not have too many items.
 
 Knowledge cutoff: 2021-09
-Current date: ${formatDate(date)}
+Current date: %today${formatDate(date)}
 Browsing: disabled
 `
 

--- a/src/services/conversation.ts
+++ b/src/services/conversation.ts
@@ -2,6 +2,8 @@ import { v4 as uuidv4 } from 'uuid'
 
 import type OpenAI from 'openai'
 
+import models from './openai/models'
+
 import formatInput from '../utils/formatInput'
 import getUnixTimestamp from '../utils/getUnixTimestamp'
 import formatChat from './openai/utils/formatChat'
@@ -63,16 +65,9 @@ export class Conversation {
     timestamp = getUnixTimestamp(),
     id = uuidv4(),
     messages = [],
-    model = OPEN_AI_DEFAULT_MODEL,
-    settings = PLUGIN_SETTINGS
+    settings = PLUGIN_SETTINGS,
+    model
   }: Partial<ConversationInterface>) {
-    this.id = id
-    this.preamble = preamble
-    this.title = title
-    this.timestamp = timestamp
-    this.messages = messages
-    this.model = model
-
     const conversationSettings = {
       maxTokens: OPEN_AI_RESPONSE_TOKENS,
       temperature: OPEN_AI_DEFAULT_TEMPERATURE,
@@ -83,6 +78,14 @@ export class Conversation {
     }
 
     this.settings = conversationSettings
+
+    this.id = id
+    this.preamble = preamble
+    this.title = title
+    this.timestamp = timestamp
+    this.messages = messages
+    this.model =
+      model ?? models[this.settings.defaultModel] ?? OPEN_AI_DEFAULT_MODEL
   }
 
   getNumberofMemoriesForState(state: MemoryState): number {

--- a/src/services/openai/adapters/chat.ts
+++ b/src/services/openai/adapters/chat.ts
@@ -1,0 +1,9 @@
+import type { ChatAdapter } from 'src/types'
+
+const OpenAIModelChatAdapter: ChatAdapter = {
+  name: 'openai',
+  engine: 'chat',
+  endpoint: '/v1/chat/completions'
+}
+
+export default OpenAIModelChatAdapter

--- a/src/services/openai/adapters/completion.ts
+++ b/src/services/openai/adapters/completion.ts
@@ -1,0 +1,9 @@
+import type { ChatAdapter } from 'src/types'
+
+const OpenAIModelCompletionAdapter: ChatAdapter = {
+  name: 'openai',
+  engine: 'completion',
+  endpoint: '/v1/completions'
+}
+
+export default OpenAIModelCompletionAdapter

--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -1,17 +1,25 @@
+import { requestUrl as obsidianRequest, type RequestUrlParam } from 'obsidian'
+
 import OpenAI from 'openai'
 import type { Stream } from 'openai/streaming'
 
 import formatChat from './utils/formatChat'
 
 import {
+  OPEN_AI_BASE_URL,
   OPEN_AI_DEFAULT_MODEL,
   OPEN_AI_RESPONSE_TOKENS,
   OPEN_AI_DEFAULT_TEMPERATURE
 } from './constants'
 
+import {
+  OPEN_AI_GPT_START_WORD,
+  OPEN_AI_GPT3_STOP_WORD
+} from './models/constants'
+
 import { PLUGIN_SETTINGS } from '../../constants'
 
-import type { OpenAICompletionRequest } from './types'
+import type { OpenAICompletionRequest, OpenAICompletion } from './types'
 import type { Conversation } from '../conversation'
 import type { PluginSettings } from '../../types'
 import type Logger from '../logger'
@@ -36,45 +44,142 @@ export const openAICompletion = async (
   { signal }: { signal?: AbortSignal },
   settings: PluginSettings = PLUGIN_SETTINGS,
   logger: Logger
-): Promise<Stream<OpenAI.Chat.ChatCompletionChunk>> => {
-  let { openAiApiKey: apiKey } = settings
+  // @ts-expect-error
+): Promise<Stream<OpenAICompletion | OpenAI.Chat.ChatCompletionChunk>> => {
+  let { openAiApiKey: apiKey, userHandle, botHandle } = settings
 
   if (safeStorage.isEncryptionAvailable() === true) {
     apiKey = await safeStorage.decryptString(Buffer.from(apiKey))
   }
 
-  try {
-    const openai = new OpenAI({
-      apiKey,
-      dangerouslyAllowBrowser: true
-    })
+  if (model.adapter.engine === 'chat') {
+    try {
+      const openai = new OpenAI({
+        apiKey,
+        dangerouslyAllowBrowser: true
+      })
 
-    const messages = formatChat(input as Conversation)
+      const messages = formatChat(input as Conversation)
 
-    const stream = await openai.chat.completions.create(
-      {
-        model: model.model,
-        messages,
-        stream: true,
-        temperature,
-        max_tokens: maxTokens,
-        top_p: topP,
-        frequency_penalty: frequencyPenalty,
-        presence_penalty: presencePenalty
-      },
-      {
-        signal
+      const stream = await openai.chat.completions.create(
+        {
+          model: model.model,
+          messages,
+          stream: true,
+          temperature,
+          max_tokens: maxTokens,
+          top_p: topP,
+          frequency_penalty: frequencyPenalty,
+          presence_penalty: presencePenalty
+        },
+        {
+          signal
+        }
+      )
+
+      return stream
+    } catch (error) {
+      if (typeof error?.response !== 'undefined') {
+        logger.error(error.response.status, error.response.data)
+      } else {
+        logger.error(error.message)
       }
-    )
 
-    return stream
-  } catch (error) {
-    if (typeof error?.response !== 'undefined') {
-      logger.error(error.response.status, error.response.data)
-    } else {
-      logger.error(error.message)
+      throw error
+    }
+  } else if (typeof model?.adapter?.endpoint !== 'undefined') {
+    // TODO: remove this now that non-chat models are being deprecated
+    const requestUrl = new URL(model?.adapter?.endpoint, OPEN_AI_BASE_URL)
+
+    const requestHeaders = {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream'
     }
 
-    throw error
+    const prompt = formatChat(input as Conversation)
+
+    const stopWords: string[] = []
+
+    if (typeof model.stopWord !== 'undefined' && model.stopWord !== '') {
+      stopWords.push(model.stopWord)
+    }
+
+    if (typeof userHandle !== 'undefined' && userHandle !== '') {
+      stopWords.push(userHandle)
+    }
+
+    if (typeof botHandle !== 'undefined' && botHandle !== '') {
+      stopWords.push(botHandle)
+    }
+
+    const requestBody = {
+      prompt: prompt
+        .reduce((promptString, message) => {
+          return (
+            `${promptString}${OPEN_AI_GPT_START_WORD}[${message.role[0].toUpperCase()}${message.role.slice(
+              1
+            )}]\n` +
+            `${message?.content as string}\n${OPEN_AI_GPT3_STOP_WORD}`.trim()
+          )
+        }, '')
+        .trim(),
+      model: model.model,
+      stream: true,
+      temperature,
+      max_tokens: maxTokens,
+      stop: stopWords,
+      top_p: topP,
+      frequency_penalty: frequencyPenalty,
+      presence_penalty: presencePenalty
+    }
+
+    const request: RequestUrlParam = {
+      url: requestUrl.toString(),
+      headers: requestHeaders,
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+      throw: false
+    }
+
+    try {
+      // borrowed from: https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams
+      const stream = await obsidianRequest(request)
+        .then(async (response) => {
+          // eslint-disable-next-line @typescript-eslint/return-await
+          return await response?.json?.()
+        })
+        .then((response) => {
+          const reader = response.body.getReader()
+          return new ReadableStream({
+            start(controller) {
+              return pump()
+              // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+              function pump() {
+                // @ts-expect-error
+                return reader.read().then(({ done, value }) => {
+                  // When no more data needs to be consumed, close the stream
+                  if (done === true) {
+                    controller.close()
+                    return
+                  }
+                  // Enqueue the next data chunk into our target stream
+                  controller.enqueue(value)
+                  return pump()
+                })
+              }
+            }
+          })
+        })
+        // Create a new response out of the stream
+        .then((stream) => new Response(stream))
+
+      // @ts-expect-error
+      return stream
+    } catch (error) {
+      logger.error(error)
+
+      throw error
+    }
   }
 }

--- a/src/services/openai/models/gpt-3.5-turbo-16k.ts
+++ b/src/services/openai/models/gpt-3.5-turbo-16k.ts
@@ -2,12 +2,12 @@ import OpenAIModelChatAdapter from '../adapters/chat'
 
 import type { ModelDefinition } from '../types'
 
-const GPT4: ModelDefinition = {
-  name: 'GPT-4',
+const GPT35Turbo16K: ModelDefinition = {
+  name: 'GPT-3.5 Turbo 16K',
   adapter: OpenAIModelChatAdapter,
-  model: 'gpt-4',
-  maxTokens: 8192,
+  model: 'gpt-3.5-turbo-16k',
+  maxTokens: 16385,
   tokenType: 'gpt4'
 }
 
-export default GPT4
+export default GPT35Turbo16K

--- a/src/services/openai/models/gpt-3.5-turbo-instruct.ts
+++ b/src/services/openai/models/gpt-3.5-turbo-instruct.ts
@@ -1,0 +1,13 @@
+import OpenAIModelCompletionAdapter from '../adapters/completion'
+
+import type { ModelDefinition } from '../types'
+
+const GPT35TurboInstruct: ModelDefinition = {
+  name: 'GPT-3.5 Turbo Instruct',
+  adapter: OpenAIModelCompletionAdapter,
+  model: 'gpt-3.5-turbo-instruct',
+  maxTokens: 8192,
+  tokenType: 'gpt4'
+}
+
+export default GPT35TurboInstruct

--- a/src/services/openai/models/gpt-3.5-turbo.ts
+++ b/src/services/openai/models/gpt-3.5-turbo.ts
@@ -1,18 +1,12 @@
-import type { ChatAdapter } from '../../../types'
+import OpenAIModelChatAdapter from '../adapters/chat'
 
 import type { ModelDefinition } from '../types'
 
-const GPT35TurboAdapter: ChatAdapter = {
-  name: 'openai',
-  engine: 'chat',
-  endpoint: '/v1/chat/completions'
-}
-
 const GPT35Turbo: ModelDefinition = {
-  name: 'GPT-3.5',
-  adapter: GPT35TurboAdapter,
+  name: 'GPT-3.5 Turbo',
+  adapter: OpenAIModelChatAdapter,
   model: 'gpt-3.5-turbo',
-  maxTokens: 4000,
+  maxTokens: 4097,
   tokenType: 'gpt4'
 }
 

--- a/src/services/openai/models/gpt-4-32k.ts
+++ b/src/services/openai/models/gpt-4-32k.ts
@@ -2,12 +2,12 @@ import OpenAIModelChatAdapter from '../adapters/chat'
 
 import type { ModelDefinition } from '../types'
 
-const GPT4: ModelDefinition = {
-  name: 'GPT-4',
+const GPT432K: ModelDefinition = {
+  name: 'GPT-4 32K',
   adapter: OpenAIModelChatAdapter,
-  model: 'gpt-4',
-  maxTokens: 8192,
+  model: 'gpt-4-32k',
+  maxTokens: 32768,
   tokenType: 'gpt4'
 }
 
-export default GPT4
+export default GPT432K

--- a/src/services/openai/models/index.ts
+++ b/src/services/openai/models/index.ts
@@ -1,9 +1,15 @@
 import GPT35Turbo from './gpt-3.5-turbo'
+import GPT35TurboInstruct from './gpt-3.5-turbo-instruct'
+import GPT35Turbo16K from './gpt-3.5-turbo-16k'
 import GPT4 from './gpt-4'
+import GPT432K from './gpt-4-32k'
 
 const models = {
   'gpt-4': GPT4,
-  'gpt-3.5-turbo': GPT35Turbo
+  'gpt-3.5-turbo': GPT35Turbo,
+  'gpt-3.5-turbo-instruct': GPT35TurboInstruct,
+  'gpt-3.5-turbo-16k': GPT35Turbo16K,
+  'gpt-4-32k': GPT432K
 }
 
 export default models

--- a/src/services/openai/types.ts
+++ b/src/services/openai/types.ts
@@ -5,10 +5,15 @@ import type { ChatAdapter } from '../../types'
 import type { TokenCounterType } from '../../utils/tokenCounter'
 
 // TODO: add other models
-export type OpenAIModel = 'gpt-3.5-turbo' | 'gpt-4'
-// | 'code-davinci-002'
+export type OpenAIModel =
+  | 'gpt-3.5-turbo'
+  | 'gpt-3.5-turbo-16k'
+  | 'gpt-3.5-turbo-instruct'
+  | 'gpt-4'
+  | 'gpt-4-32k'
 
 // TODO: find out what other valid object values are
+// tODO: It think this was deprecated with the older completion models
 export type OpenAICompletionObject = 'text_completion'
 
 export interface ModelDefinition {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ import type {
 // TODO: update this union type with other valid adapters as they are added
 export type ChatAdapterName = 'openai'
 
-export type ChatAdapterEngine = 'chat' | 'code' | 'prompt'
+export type ChatAdapterEngine = 'chat' | 'code' | 'prompt' | 'completion'
 
 export type MemoryState =
   | 'default'


### PR DESCRIPTION
<!--
Thanks for contributing to the Obsidian AI Research Assistant Plugin!

* New contributors are highly encouraged to read our
  [Contributor's Guide](./docs/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Should pass all status checks before being reviewed or merged.
* Commits should Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
* Draft PRs should use the Draft functionality

-->

### What does this PR do?

Adds support for the following models:

- `gpt-3.5-turbo-instruct`
- `gpt-4-32k`
- `gpt-3.5-turbo-16k`

And reintroduces the previously deprecated `completion` engine for model adapters to account for `gpt-3.5-turbo-instruct` using the legacy completion endpoint instead of the chat endpoint.
