### PR TITLE
feat: store API keys in Obsidian SecretStorage via SecretComponent

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -57,7 +57,7 @@ export default class ObsidianAIResearchAssistant extends Plugin {
 
   async initializeChatService(): Promise<void> {
     const { activeProviderId, providers } = this.settings
-    const apiKey = (await this.getSecret(`${activeProviderId}-api-key`)) ?? ''
+    const apiKey = this.getProviderApiKey(activeProviderId) ?? ''
     const adapter = createAdapter(this.settings, apiKey)
 
     // Resolve a ModelDefinition for the active provider so the Conversation
@@ -138,24 +138,22 @@ export default class ObsidianAIResearchAssistant extends Plugin {
   async loadSettings(): Promise<void> {
     const loaded: Record<string, unknown> = (await this.loadData()) ?? {}
 
-    // ─── Migrate legacy flat API key to SecretStorage ──────────────────────
+    // 1.4+ keys were encrypted via Electron's `remote.safeStorage`, which is
+    // gone from modern Electron — we can't decrypt that blob from a renderer.
+    // Carry the value over verbatim: plaintext (pre-1.4) keys work; encrypted
+    // blobs will fail auth and the user re-enters in settings.
+    let migratedOpenAiKey: string | undefined
     if (typeof loaded.openAiApiKey === 'string' && loaded.openAiApiKey !== '') {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const Electron = require('electron')
-        const {
-          remote: { safeStorage }
-        } = Electron
-        let key = loaded.openAiApiKey
-        if (safeStorage.isEncryptionAvailable() === true) {
-          key = safeStorage.decryptString(Buffer.from(key))
-        }
-        await this.setSecret('openai-api-key', key)
-      } catch {
-        // Migration failed — user will need to re-enter their key in settings
-      }
+      const secretId = 'openai-api-key'
+      this.app.secretStorage.setSecret(secretId, loaded.openAiApiKey)
+      migratedOpenAiKey = secretId
       delete loaded.openAiApiKey
       delete loaded.apiKeySaved
+      // eslint-disable-next-line no-new
+      new Notice(
+        `${PLUGIN_NAME}: moved your OpenAI key into Obsidian's secret storage. If chat fails to authenticate, re-enter the key in Settings.`,
+        10000
+      )
     }
 
     this.settings = Object.assign({}, PLUGIN_SETTINGS, loaded)
@@ -184,6 +182,16 @@ export default class ObsidianAIResearchAssistant extends Plugin {
     ) {
       this.settings.defaultModel = activeCfg.defaultModel
     }
+
+    if (migratedOpenAiKey !== undefined) {
+      const openAiCfg = this.settings.providers.openai as
+        | PluginSettings['providers'][string]
+        | undefined
+      if (openAiCfg !== undefined) {
+        openAiCfg.apiKeySecret = migratedOpenAiKey
+        await this.saveData(this.settings)
+      }
+    }
   }
 
   async saveSettings(): Promise<void> {
@@ -201,14 +209,20 @@ export default class ObsidianAIResearchAssistant extends Plugin {
   }
 
   // ─── SecretStorage ────────────────────────────────────────────────────────
-  // Uses Obsidian's official secret storage API (available since 1.11.4).
+  // The settings UI writes API keys via Obsidian's `SecretComponent`, which
+  // owns the storage round-trip. We only ever read.
 
-  async getSecret(key: string): Promise<string | undefined> {
-    return this.app.secretStorage.getSecret(key) ?? undefined
-  }
-
-  async setSecret(key: string, value: string): Promise<void> {
-    this.app.secretStorage.setSecret(key, value)
+  getProviderApiKey(providerId: string): string | undefined {
+    const cfg = this.settings.providers[providerId] as
+      | PluginSettings['providers'][string]
+      | undefined
+    const secretId = cfg?.apiKeySecret
+    if (secretId === undefined || secretId === '') return undefined
+    try {
+      return this.app.secretStorage.getSecret(secretId) ?? undefined
+    } catch {
+      return undefined
+    }
   }
 
   async checkForExistingFile(title: string): Promise<boolean> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,8 @@ export interface ProviderSettings {
   name: string
   baseUrl?: string
   defaultModel: string
+  /** Secret ID in Obsidian SecretStorage that holds this provider's API key. */
+  apiKeySecret?: string
   /** Model IDs currently shown in the model picker (subset of known + custom). */
   enabledModels: string[]
   /** User-added model IDs beyond the bundled catalog. */

--- a/src/utils/obfuscateApiKey.ts
+++ b/src/utils/obfuscateApiKey.ts
@@ -1,4 +1,0 @@
-const obfuscateApiKey = (apiKey = ''): string =>
-  apiKey.length > 0 ? apiKey.replace(/^(.{3})(.*)(.{4})$/, '$1****$3') : ''
-
-export default obfuscateApiKey

--- a/src/views/SettingsTab.ts
+++ b/src/views/SettingsTab.ts
@@ -1,4 +1,10 @@
-import { type App, PluginSettingTab, Setting, normalizePath } from 'obsidian'
+import {
+  type App,
+  PluginSettingTab,
+  SecretComponent,
+  Setting,
+  normalizePath
+} from 'obsidian'
 
 import {
   BOT_HANDLE,
@@ -355,21 +361,15 @@ export default class SettingsTab extends PluginSettingTab {
         )
     }
 
-    new Setting(inner)
+    const apiKeySetting = new Setting(inner)
       .setName('API key')
-      .setDesc('Stored per-device and not synced.')
-      .addText((text) => {
-        text.inputEl.type = 'password'
-        text.inputEl.autocomplete = 'off'
-        void this.plugin.getSecret(`${id}-api-key`).then((key) => {
-          if (key !== undefined && key !== '') text.setValue('••••••••')
-        })
-        text.onChange(async (value) => {
-          if (value !== '' && value !== '••••••••') {
-            await this.plugin.setSecret(`${id}-api-key`, value)
-          }
-        })
-        return text
+      .setDesc("Stored in Obsidian's SecretStorage (per-device, not synced).")
+    new SecretComponent(this.app, apiKeySetting.controlEl)
+      .setValue(cfg.apiKeySecret ?? '')
+      .onChange(async (value) => {
+        cfg.apiKeySecret = value
+        await this.plugin.saveSettings()
+        await this.plugin.reinitializeProvider(id)
       })
 
     this.renderModelSection(inner, id)


### PR DESCRIPTION
Move API keys out of plugin settings JSON and into Obsidian's SecretStorage. The settings UI uses Obsidian's SecretComponent, which owns the write path — actual key values never round-trip through the settings DOM after entry. ProviderSettings now carries an opaque `apiKeySecret` ID; the plugin reads the value at API-call time only via getProviderApiKey().

Legacy `openAiApiKey` migration carries the value over verbatim under secret ID `openai-api-key` and notices the user. 1.4+ keys were encrypted via Electron's `remote.safeStorage`, which is gone from modern Electron, so those will fail auth and require re-entry.

Closes #29